### PR TITLE
Correct logic for Past Owl Statue Chest

### DIFF
--- a/locations/overworld/sacred grove.json
+++ b/locations/overworld/sacred grove.json
@@ -42,7 +42,7 @@
 					{
 						"access_rules": [
 							"@SacredGrovePast, dominionrod",
-							"[glitcheson], @SacredGrovePast, $canDoLJA"
+							"[glitcheson], @SacredGrovePast, shadowcrystal"
 						]
 					}
 				]


### PR DESCRIPTION
Updates the logic for this check to match [TP Randomizer](https://github.com/zsrtp/Randomizer-Web-Generator/blob/2025e1ff8cc628588ebc58b284c25ee571a31df7/Generator/World/Checks/Overworld/Faron%20Province/Sacred%20Grove%20Past%20Owl%20Statue%20Chest.jsonc#L3) and [TP Archipelago](https://github.com/WritingHusky/Twilight_Princess_apworld/blob/585e3417aed09673058621764dfaa6a41c0c6499/Logic/Rules.py#L2899-L2901). I'm not sure it's possible to get this check with an LJA.